### PR TITLE
fix: resolve double-quote escaping issue in generated XPath strings

### DIFF
--- a/background.js
+++ b/background.js
@@ -410,6 +410,11 @@ function pushAction(a) {
     });
 }
 
+function fixXpathDoubleQuoteIssues(xpathString) {
+    // avoid unescaped double quotes in Python strings
+    return xpathString.replace(/(\[@[a-zA-Z]+)="([^"]*)"]/g, "$1='$2']");
+}
+
 function convertToSelenium(trackingLog) {
     // Create xpath mapping
     const xpathMap = {};
@@ -427,8 +432,9 @@ function convertToSelenium(trackingLog) {
             
             // Store original xpaths in map and replace with placeholders
             simplifiedAction.xpath = xpathArray.map(xpath => {
+                const fixedXpath = fixXpathDoubleQuoteIssues(xpath);
                 const placeholder = `XPATH-#${xpathCounter}`;
-                xpathMap[placeholder] = xpath;
+                xpathMap[placeholder] = fixedXpath;
                 xpathCounter++;
                 return placeholder;
             });


### PR DESCRIPTION
# Fix: Resolve Double-Quote Escaping Issue in Generated XPath Strings

## Description

This PR addresses an issue in the `AutoMouser` Chrome extension where generated Selenium test scripts fail due to unescaped double quotes in XPath strings. Specifically, when actions like `CLICK` or `INPUT` are recorded, the generated `selenium_test.py` contains invalid Python syntax because XPath strings are not properly escaped.

### Steps to Reproduce the Issue

1. Start the `AutoMouser` Chrome extension.
2. Perform the following actions on a webpage:
   - Navigate to `google.com`.
   - Enter "12345" into the search bar.
   - Press `Enter`.
3. Stop recording and generate the `selenium_test.py`.
4. Attempt to execute the script. The following error occurs:

   ```plaintext
   File "selenium_test.py", line 70
       {"type": "CLICK", "xpath": ["//textarea[@id='APjFqb']", ... , "//*[@id="APjFqb"]"], "timestamp": 1736334309663},
                                                                                                    ^^^^^^^^^^^^^^^^
   SyntaxError: invalid syntax. Perhaps you forgot a comma?
   ```

### Root Cause

In the generated `selenium_test.py`, XPath strings with attributes like `[@id="value"]` result in invalid Python syntax due to unescaped double quotes. For example:

```python
"//*[@id="APjFqb"]"
```

### Solution

Added a function to escape double quotes in XPath strings before writing them to the Selenium test script. The function replaces double quotes inside square brackets with single quotes, ensuring valid Python syntax.

#### Added Function

```javascript
function fixXpathDoubleQuoteIssues(xpathString) {
    // Avoid unescaped double quotes in Python strings
    return xpathString.replace(/(\[@[a-zA-Z]+)="([^"]*)"]/g, "$1='$2']");
}
```

### Impact

This fix ensures that generated Selenium test scripts are syntactically valid and can be executed without modification.

### How to Test

1. Apply the fix.
2. Generate a new `selenium_test.py` by performing the same steps as mentioned in "Steps to Reproduce."
3. Execute the script. It should run without any syntax errors.

---

@guoriyue When you have time, could you please take a look at this PR? Let me know if there's anything I can improve or clarify. Thanks for your time and help!